### PR TITLE
fix: clone FormData on retry after token refresh

### DIFF
--- a/lib/src/dio_refresh.dart
+++ b/lib/src/dio_refresh.dart
@@ -152,7 +152,8 @@ class DioRefreshInterceptor extends Interceptor {
         final res = await dio.request(
           request.path,
           cancelToken: request.cancelToken,
-          data: request.data,
+          // Clone FormData to avoid an error about submitting it twice.
+          data: request.data is FormData ? request.data.clone() : request.data,
           onReceiveProgress: request.onReceiveProgress,
           onSendProgress: request.onSendProgress,
           queryParameters: request.queryParameters,


### PR DESCRIPTION
If the data for the request is a FormData, an error is thrown if the same FormData is used for the retry request. Fix this by cloning the FormData for the retry.