### PR TITLE
feat: add TokenIsValidCallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ print(tokenManager.accessToken);
     - `authHeader`: Callback to generate authorization headers.
     - `shouldRefresh`: Callback to determine if a refresh is needed.
     - `onRefresh`: Callback to handle the refresh logic and return a new `TokenStore`.
+    - `isTokenValid`: Optional callback to validate if a token is still valid.
 
 ### `TokenManager`
 
@@ -128,6 +129,34 @@ print(tokenManager.accessToken);
     - Determines if a token refresh is required.
 - **`TokenHeaderCallback`**: `Map<String, String> Function(TokenStore)`
     - Generates authorization headers for requests.
+- **`IsTokenValidCallback`**: `bool Function(String)`
+    - Validates if a token is still valid.
+    - Default implementation checks if the JWT token is not expired.
+    - Called if [shouldRefresh] returns `true`.
+    - Can be customized to implement different token validation strategies.
+
+### Example with Custom Token Validation
+
+```dart
+final dio = Dio();
+dio.interceptors.add(DioRefreshInterceptor(
+  tokenManager: tokenManager,
+  onRefresh: onRefresh,
+  shouldRefresh: shouldRefresh,
+  authHeader: authHeader,
+  isTokenValid: (token) {
+    // Implement custom token validation logic
+    try {
+      final decodedToken = JwtDecoder.decode(token);
+      // Add additional validation checks here
+      return !JwtDecoder.isExpired(token) && 
+             decodedToken['custom_claim'] == 'expected_value';
+    } catch (_) {
+      return false;
+    }
+  },
+));
+```
 
 ## Contributing
 

--- a/lib/src/dio_refresh.dart
+++ b/lib/src/dio_refresh.dart
@@ -57,22 +57,22 @@ class DioRefreshInterceptor extends Interceptor {
   /// This is called if [shouldRefresh] returns `true`.
   /// If not specified, the default is to check that the token can be decoded
   /// and has not expired.
-  late final TokenIsValidCallback tokenIsValid;
+  late final IsTokenValidCallback isTokenValid;
 
   /// Creates an instance of `DioRefreshInterceptor`.
   ///
   /// The interceptor requires a [tokenManager] to handle the token state, an [onRefresh]
   /// callback to manage the refresh process, a [shouldRefresh] callback to determine when
   /// to refresh, and an [authHeader] callback to provide the necessary authentication headers.
-  /// An optional [tokenIsValid] callback can be provided to customize the token validation process.
+  /// An optional [isTokenValid] callback can be provided to customize the token validation process.
   DioRefreshInterceptor({
     required this.tokenManager,
     required this.onRefresh,
     required this.shouldRefresh,
     required this.authHeader,
-    TokenIsValidCallback? tokenIsValid,
+    IsTokenValidCallback? isTokenValid,
   }) {
-    this.tokenIsValid = tokenIsValid?? _isAccessTokenValid;
+    this.isTokenValid = isTokenValid ?? _isAccessTokenValid;
   }
 
   /// Intercepts outgoing requests to add authorization headers.
@@ -111,7 +111,7 @@ class DioRefreshInterceptor extends Interceptor {
         await _checkForRefreshToken();
       } else {
         await synchronized(() async {
-          bool isAccessTokenValid = tokenIsValid(tokenManager.accessToken!);
+          bool isAccessTokenValid = isTokenValid(tokenManager.accessToken!);
           if (!isAccessTokenValid) {
             try {
               tokenManager.isRefreshing.value = true;
@@ -211,7 +211,7 @@ class DioRefreshInterceptor extends Interceptor {
     return completer.future;
   }
 
-  /// The default callback for the [TokenIsValidCallback].
+  /// The default callback for the [IsTokenValidCallback].
   ///
   /// The token is valid if it can be decoded and the expiration time has not passed.
   bool _isAccessTokenValid(String accessToken) {

--- a/lib/src/types.dart
+++ b/lib/src/types.dart
@@ -62,3 +62,21 @@ typedef ShouldRefreshCallback = bool Function(Response?);
 /// }
 /// ```
 typedef TokenHeaderCallback = Map<String, String> Function(TokenStore);
+
+/// A callback function to check whether a token is valid.
+///
+/// This function is called if there is an access token present in the [TokenStore]
+/// and the [OnRefreshCallback] indicates that a token refresh is required.
+///
+/// The default implementation checks if the access token is not expired.
+///
+/// Example:
+/// ```dart
+/// bool isValidToken(String accessToken) {
+///   try {
+///     return !JwtDecoder.isExpired(accessToken);
+///   } catch (_) {}
+///   return false;
+/// }
+/// ```
+typedef TokenIsValidCallback = bool Function(String);

--- a/lib/src/types.dart
+++ b/lib/src/types.dart
@@ -72,11 +72,11 @@ typedef TokenHeaderCallback = Map<String, String> Function(TokenStore);
 ///
 /// Example:
 /// ```dart
-/// bool isValidToken(String accessToken) {
+/// bool isTokenValid(String accessToken) {
 ///   try {
 ///     return !JwtDecoder.isExpired(accessToken);
 ///   } catch (_) {}
 ///   return false;
 /// }
 /// ```
-typedef TokenIsValidCallback = bool Function(String);
+typedef IsTokenValidCallback = bool Function(String);


### PR DESCRIPTION
Replace the default check for a valid token with an optional callback function. This allows clients to always refresh a token if the server returns a 401 error, or to handle clock skew when checking for expired tokens.