### PR TITLE
feat: add retryInterceptors for custom retry logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ print(tokenManager.accessToken);
     - `shouldRefresh`: Callback to determine if a refresh is needed.
     - `onRefresh`: Callback to handle the refresh logic and return a new `TokenStore`.
     - `isTokenValid`: Optional callback to validate if a token is still valid.
-    - `retryInterceptors`: Optional list of interceptors to be added to the `Dio` instance used for retrying requests. This is useful for adding logging or other custom interceptors to the retry mechanism.
+    - `retryInterceptors`: Optional list of interceptors to be added to the `Dio` instance used for retrying requests. This is useful for adding logging or other custom interceptors to the retry mechanism. **Note:** Do not add another `DioRefreshInterceptor` to this list, as it may cause an infinite loop.
 
 ### `TokenManager`
 
@@ -162,6 +162,8 @@ dio.interceptors.add(DioRefreshInterceptor(
 ### Example with `retryInterceptors`
 
 You can provide a list of custom interceptors that will be added to the `Dio` instance responsible for retrying the request after a successful token refresh. This is particularly useful for logging the retry attempts.
+
+**Important:** Do not add an instance of `DioRefreshInterceptor` itself to the `retryInterceptors` list. Doing so may create an infinite loop if the token refresh request also fails. The constructor includes an assertion to prevent this in debug mode.
 
 First, create a logger interceptor. For example, a simple `CustomLogInterceptor`:
 

--- a/lib/src/dio_refresh.dart
+++ b/lib/src/dio_refresh.dart
@@ -56,6 +56,9 @@ class DioRefreshInterceptor extends Interceptor {
   ///
   /// This allows you to add custom interceptors, such as for logging, to the `Dio` instance
   /// that handles the request retry process.
+  ///
+  /// **Note:** Do not add another `DioRefreshInterceptor` to this list, as it may cause
+  /// an infinite loop. An assertion is in place to prevent this during development.
   final List<Interceptor>? retryInterceptors;
 
   /// An optional callback to check if a token is valid.
@@ -79,6 +82,10 @@ class DioRefreshInterceptor extends Interceptor {
     this.retryInterceptors,
     IsTokenValidCallback? isTokenValid,
   }) {
+    assert(
+      retryInterceptors?.any((i) => i is DioRefreshInterceptor) != true,
+      'Cannot add a DioRefreshInterceptor to the retryInterceptors, as it may cause an infinite loop.',
+    );
     this.isTokenValid = isTokenValid ?? _isAccessTokenValid;
   }
 

--- a/lib/src/dio_refresh.dart
+++ b/lib/src/dio_refresh.dart
@@ -52,6 +52,12 @@ class DioRefreshInterceptor extends Interceptor {
   /// headers). These headers are added to the request before it is sent.
   final TokenHeaderCallback authHeader;
 
+  /// A list of interceptors to be added to the `Dio` instance used for retrying requests.
+  ///
+  /// This allows you to add custom interceptors, such as for logging, to the `Dio` instance
+  /// that handles the request retry process.
+  final List<Interceptor>? retryInterceptors;
+
   /// An optional callback to check if a token is valid.
   ///
   /// This is called if [shouldRefresh] returns `true`.
@@ -70,6 +76,7 @@ class DioRefreshInterceptor extends Interceptor {
     required this.onRefresh,
     required this.shouldRefresh,
     required this.authHeader,
+    this.retryInterceptors,
     IsTokenValidCallback? isTokenValid,
   }) {
     this.isTokenValid = isTokenValid ?? _isAccessTokenValid;
@@ -154,6 +161,9 @@ class DioRefreshInterceptor extends Interceptor {
         request.headers = {...request.headers, ...header};
 
         final dio = Dio(BaseOptions(baseUrl: request.baseUrl));
+        if (retryInterceptors != null) {
+          dio.interceptors.addAll(retryInterceptors!);
+        }
         final res = await dio.request(
           request.path,
           cancelToken: request.cancelToken,


### PR DESCRIPTION
Adds an optional retryInterceptors parameter to DioRefreshInterceptor, allowing custom Interceptors to be added to the retry Dio instance (e.g., for logging).
Since the refreshDio can be customized via the onRefresh callback, this is only needed for retry-specific logic.