### PR TITLE
[v1.0.6]: fix shouldRefresh not being regarded if token is valid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.0.6
+
+* Fix: Refresh is now triggered when either the server requests it (shouldRefresh) or the token is
+  locally expired. Previously both conditions were required, causing refresh to be skipped in
+  revoked-token scenarios
+
 ## 1.0.5
 
 * Added retry interceptors

--- a/lib/src/dio_refresh.dart
+++ b/lib/src/dio_refresh.dart
@@ -119,46 +119,45 @@ class DioRefreshInterceptor extends Interceptor {
   ) async {
     final request = err.requestOptions;
     final response = err.response;
+    bool isAccessTokenValid = isTokenValid(tokenManager.accessToken!);
+    bool shouldRefreshToken = shouldRefresh(response) || !isAccessTokenValid;
 
-    if (tokenManager.accessToken != null && shouldRefresh(response)) {
+    if (tokenManager.accessToken != null && shouldRefreshToken) {
       if (tokenManager.isRefreshing.value) {
         await _checkForRefreshToken();
       } else {
         await synchronized(() async {
-          bool isAccessTokenValid = isTokenValid(tokenManager.accessToken!);
-          if (!isAccessTokenValid) {
-            try {
-              tokenManager.isRefreshing.value = true;
+          try {
+            tokenManager.isRefreshing.value = true;
 
-              final headers = {...request.headers};
-              headers.remove(HttpHeaders.contentLengthHeader);
+            final headers = {...request.headers};
+            headers.remove(HttpHeaders.contentLengthHeader);
 
-              final refreshDio = Dio(BaseOptions(
-                sendTimeout: request.sendTimeout,
-                receiveTimeout: request.receiveTimeout,
-                extra: request.extra,
-                headers: headers,
-                responseType: request.responseType,
-                contentType: request.contentType,
-                validateStatus: request.validateStatus,
-                receiveDataWhenStatusError: request.receiveDataWhenStatusError,
-                followRedirects: request.followRedirects,
-                maxRedirects: request.maxRedirects,
-                requestEncoder: request.requestEncoder,
-                responseDecoder: request.responseDecoder,
-                listFormat: request.listFormat,
-              ));
-              final refreshResponse = await onRefresh(
-                refreshDio,
-                tokenManager.tokenStore,
-              );
+            final refreshDio = Dio(BaseOptions(
+              sendTimeout: request.sendTimeout,
+              receiveTimeout: request.receiveTimeout,
+              extra: request.extra,
+              headers: headers,
+              responseType: request.responseType,
+              contentType: request.contentType,
+              validateStatus: request.validateStatus,
+              receiveDataWhenStatusError: request.receiveDataWhenStatusError,
+              followRedirects: request.followRedirects,
+              maxRedirects: request.maxRedirects,
+              requestEncoder: request.requestEncoder,
+              responseDecoder: request.responseDecoder,
+              listFormat: request.listFormat,
+            ));
+            final refreshResponse = await onRefresh(
+              refreshDio,
+              tokenManager.tokenStore,
+            );
 
-              tokenManager.setToken(refreshResponse);
-              tokenManager.isRefreshing.value = false;
-            } catch (e) {
-              tokenManager.isRefreshing.value = false;
-              handler.next(err);
-            }
+            tokenManager.setToken(refreshResponse);
+            tokenManager.isRefreshing.value = false;
+          } catch (e) {
+            tokenManager.isRefreshing.value = false;
+            handler.next(err);
           }
         });
       }

--- a/lib/src/dio_refresh.dart
+++ b/lib/src/dio_refresh.dart
@@ -119,8 +119,9 @@ class DioRefreshInterceptor extends Interceptor {
   ) async {
     final request = err.requestOptions;
     final response = err.response;
-    bool shouldRefreshToken =
-        shouldRefresh(response) || !isTokenValid(tokenManager.accessToken!);
+    bool shouldRefreshToken = shouldRefresh(response) ||
+        (tokenManager.accessToken != null &&
+            !isTokenValid(tokenManager.accessToken!));
 
     if (tokenManager.accessToken != null && shouldRefreshToken) {
       if (tokenManager.isRefreshing.value) {

--- a/lib/src/dio_refresh.dart
+++ b/lib/src/dio_refresh.dart
@@ -119,8 +119,8 @@ class DioRefreshInterceptor extends Interceptor {
   ) async {
     final request = err.requestOptions;
     final response = err.response;
-    bool isAccessTokenValid = isTokenValid(tokenManager.accessToken!);
-    bool shouldRefreshToken = shouldRefresh(response) || !isAccessTokenValid;
+    bool shouldRefreshToken =
+        shouldRefresh(response) || !isTokenValid(tokenManager.accessToken!);
 
     if (tokenManager.accessToken != null && shouldRefreshToken) {
       if (tokenManager.isRefreshing.value) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dio_refresh
 description: "A flutter package for intercepting requests and automatically fetching refresh tokens on API failures"
-version: 1.0.5
+version: 1.0.6
 homepage: https://github.com/iamdipanshusingh/dio_refresh
 repository: https://github.com/iamdipanshusingh/dio_refresh
 topics:


### PR DESCRIPTION
Refresh is now triggered when either the server requests it (shouldRefresh) or the token is locally expired. Previously both conditions were required, causing refresh to be skipped in revoked-token scenarios